### PR TITLE
v1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.mortaldev</groupId>
     <artifactId>JBCreditShop</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
 
     <name>JBCreditShop</name>

--- a/src/main/java/me/mortaldev/jbcreditshop/menus/CustomStyleMenu.java
+++ b/src/main/java/me/mortaldev/jbcreditshop/menus/CustomStyleMenu.java
@@ -26,7 +26,7 @@ public class CustomStyleMenu extends InventoryGUI {
   public CustomStyleMenu(Shop shop, boolean adminMode) {
     this.adminMode = adminMode;
     this.shop = shop;
-    this.shopItems = ShopItemsManager.getInstance().getByShopID(shop.getShopID(), false);
+    this.shopItems = ShopItemsManager.getInstance().getItemsByShopID(shop.getShopID(), false);
     sortSlots();
   }
 
@@ -69,7 +69,7 @@ public class CustomStyleMenu extends InventoryGUI {
   }
 
   private int autoGenSize() {
-    return Utils.clamp((int) Math.ceil(slotted.size() / 9.0), 1, 6);
+    return Utils.clamp((int) Math.ceil(slotted.size() / 9.0)+1, 1, 6);
   }
 
   @Override

--- a/src/main/java/me/mortaldev/jbcreditshop/menus/ShopSettingsMenu.java
+++ b/src/main/java/me/mortaldev/jbcreditshop/menus/ShopSettingsMenu.java
@@ -1,13 +1,12 @@
 package me.mortaldev.jbcreditshop.menus;
 
 import java.util.Collections;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import me.mortaldev.jbcreditshop.Main;
 import me.mortaldev.jbcreditshop.listeners.ChatListener;
-import me.mortaldev.jbcreditshop.modules.MenuData;
-import me.mortaldev.jbcreditshop.modules.Shop;
-import me.mortaldev.jbcreditshop.modules.ShopManager;
+import me.mortaldev.jbcreditshop.modules.*;
 import me.mortaldev.jbcreditshop.utils.ItemStackHelper;
 import me.mortaldev.jbcreditshop.utils.TextUtil;
 import me.mortaldev.menuapi.GUIManager;
@@ -77,6 +76,8 @@ public class ShopSettingsMenu extends InventoryGUI {
                       "Delete Shop? &l" + shop.getShopID(),
                       ShopManager.getInstance().getShopMenuStack(shop, false),
                       player1 -> {
+                        Set<ShopItem> byShopID = ShopItemsManager.getInstance().getItemsByShopID(shop.getShopID(), true);
+                        byShopID.forEach(ShopItemsManager.getInstance()::deleteShopItem);
                         ShopManager.getInstance().deleteShop(shop);
                         GUIManager.getInstance().openGUI(new ShopsMenu(new MenuData()), player);
                       },

--- a/src/main/java/me/mortaldev/jbcreditshop/menus/ShopsMenu.java
+++ b/src/main/java/me/mortaldev/jbcreditshop/menus/ShopsMenu.java
@@ -1,8 +1,6 @@
 package me.mortaldev.jbcreditshop.menus;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import me.mortaldev.jbcreditshop.Main;
 import me.mortaldev.jbcreditshop.modules.MenuData;
@@ -52,7 +50,7 @@ public class ShopsMenu extends InventoryGUI {
       if (mod > 0) {
         size = size % mod;
       }
-      return Utils.clamp((int) Math.ceil(size / 9.0), 2, 6);
+      return Utils.clamp((int) Math.ceil(size / 9.0)+1, 2, 6);
     }
     return 6;
   }
@@ -74,7 +72,7 @@ public class ShopsMenu extends InventoryGUI {
     return filtered;
   }
 
-  private Set<Shop> applyPage(Set<Shop> shops) {
+  private LinkedHashSet<Shop> applyPage(Set<Shop> shops) {
     int page = menuData.getPage();
     if (page > getMaxPage()) {
       page = getMaxPage();
@@ -82,7 +80,12 @@ public class ShopsMenu extends InventoryGUI {
     return shops.stream()
         .skip((page - 1) * 45L)
         .limit(45)
-        .collect(Collectors.toCollection(HashSet::new));
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private LinkedHashSet<Shop> applySort(Set<Shop> shops) {
+    LinkedHashSet<Shop> result = new LinkedHashSet<>(shops);
+    return result.stream().sorted(Comparator.comparing(Shop::getShopID)).collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   @Override
@@ -99,7 +102,8 @@ public class ShopsMenu extends InventoryGUI {
       addButton(0, BackButton());
     }
     Set<Shop> filtered = applySearch(shops);
-    Set<Shop> pageAdjusted = applyPage(filtered);
+    LinkedHashSet<Shop> sorted = applySort(filtered);
+    LinkedHashSet<Shop> pageAdjusted = applyPage(sorted);
     int slot = 0;
     for (Shop shop : pageAdjusted) {
       addButton(slot + 9, ShopButton(shop));

--- a/src/main/java/me/mortaldev/jbcreditshop/modules/ShopItemsManager.java
+++ b/src/main/java/me/mortaldev/jbcreditshop/modules/ShopItemsManager.java
@@ -102,7 +102,8 @@ public class ShopItemsManager {
     if (adminMode) {
       builder
           .addLore("&3&lID: &f" + shopItem.getItemID())
-          .addLore("&3&lShop ID: &f" + shopItem.getShopID());
+          .addLore("&3&lShop ID: &f" + shopItem.getShopID())
+          .addLore("&3&lGroup: &f" + (shopItem.getGroup() == null || shopItem.getGroup().isEmpty() ? "&7( NONE )" : shopItem.getGroup()));
     }
     String formattedPrice = formatPrice(shopItem.getPrice());
     if (adminMode) {
@@ -233,11 +234,14 @@ public class ShopItemsManager {
   }
 
   public void loadShopItems() {
+    shopItems.clear();
+    shopItemsByShopID.clear();
     shopItems = ShopItemsYaml.getInstance().read();
     sortByShop();
   }
 
   public void sortByShop() {
+    shopItemsByShopID.clear();
     for (ShopItem shopItem : shopItems) {
       if (!shopItemsByShopID.containsKey(shopItem.getShopID())) {
         shopItemsByShopID.put(
@@ -265,7 +269,7 @@ public class ShopItemsManager {
     return null;
   }
 
-  public Set<ShopItem> getByShopID(String shopID, boolean sortByShop) {
+  public Set<ShopItem> getItemsByShopID(String shopID, boolean sortByShop) {
     if (sortByShop) {
       sortByShop();
     }

--- a/src/main/java/me/mortaldev/jbcreditshop/modules/ShopManager.java
+++ b/src/main/java/me/mortaldev/jbcreditshop/modules/ShopManager.java
@@ -26,6 +26,7 @@ public class ShopManager {
   private ShopManager() {}
 
   public void loadShops() {
+    shops.clear();
     shops = ShopsYaml.getInstance().read();
   }
 


### PR DESCRIPTION
feat: Added 'group' lore to admin view of items.
feat: Deleting a shop deletes it's associated items. (may change if #5 is added)

Fixed #8 in last commit
Fixes #7:
 Filters before calculating pages.
Fixes #6 (maybe):
 Clears the current loaded shopItems set and shops set before loading again. (was causing issues and dupes)